### PR TITLE
feature:OP-19353:added new Dockerfileubi8 for RHEL ubi8.7-minimal-changes

### DIFF
--- a/Dockerfile.ubi8-minimal
+++ b/Dockerfile.ubi8-minimal
@@ -1,0 +1,58 @@
+FROM ubuntu:bionic AS build
+RUN apt-get update && apt-get install -y \
+    openjdk-11-jdk \
+ && rm -rf /var/lib/apt/lists/*
+LABEL maintainer="sig-platform@spinnaker.io"
+ENV GRADLE_USER_HOME /workspace/.gradle
+ENV GRADLE_OPTS "-Xmx4g -Xms2g"
+WORKDIR /build
+COPY . /build
+RUN ./gradlew --no-daemon clouddriver-web:installDist -x test
+
+FROM quay.io/opsmxpublic/image-base-java-ubi8-minimal:latest AS package
+LABEL maintainer="info@opsmx.io"
+
+# KUBECTL_RELEASE kept one minor version behind latest to maximise compatibility overlap
+ENV KUBECTL_RELEASE=1.20.6
+ENV AWS_CLI_VERSION=1.18.152
+ENV AWS_CLI_S3_CMD=2.0.2
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.5
+ENV GOOGLE_CLOUD_SDK_VERSION=418.0.0
+ENV ECR_TOKEN_VERSION=v1.0.2
+
+ARG TARGETARCH
+
+
+ENV PATH "$PATH:/usr/local/bin/:/opt/google-cloud-sdk/bin/:/usr/local/bin/aws-iam-authenticator"
+
+RUN  microdnf install --setopt=tsflags=nodocs ca-certificates wget git openssh-clients python3-pip tar \
+  && pip3 install --upgrade awscli==${AWS_CLI_VERSION} s3cmd==${AWS_CLI_S3_CMD} python-magic \
+  && python3 -m pip uninstall pip -y 
+
+RUN  [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \
+  && wget -nv https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
+  && mkdir -p /opt && cd /opt \
+  && tar -xzf /google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
+  && rm /google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
+  && CLOUDSDK_PYTHON="python3" /opt/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false \
+     --additional-components app-engine-java app-engine-go gke-gcloud-auth-plugin \
+  && rm -rf ~/.config/gcloud \
+  && rm -rf /opt/google-cloud-sdk/.install/.backup 
+
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/${TARGETARCH}/kubectl \
+  && chmod +x kubectl \
+  && mv ./kubectl /usr/local/bin/kubectl \
+  && wget -O aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_AIM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AWS_AIM_AUTHENTICATOR_VERSION}_linux_${TARGETARCH} \
+	&& chmod +x ./aws-iam-authenticator \
+	&& mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator\
+    && ln -sf /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws 
+
+RUN groupadd -g 10111 spinnaker \
+  && useradd -g spinnaker -u 10111 spinnaker \
+  && mkdir -p /opt/clouddriver/plugins && chown -R spinnaker:spinnaker /opt/clouddriver/plugins
+
+COPY --from=build /build/clouddriver-web/build/install/clouddriver /opt/clouddriver
+
+USER spinnaker
+
+CMD ["/opt/clouddriver/bin/clouddriver"]

--- a/Dockerfileubi8
+++ b/Dockerfileubi8
@@ -1,0 +1,65 @@
+#FROM python:3.7-alpine3.16
+#LABEL maintainer="sig-platform@spinnaker.io"
+#
+FROM quay.io/opsmxpublic/ubi8-jdk-11:v1
+LABEL maintainer="info@opsmx.io"
+
+# KUBECTL_RELEASE kept one minor version behind latest to maximise compatibility overlap
+ENV KUBECTL_RELEASE=1.20.6
+ENV AWS_CLI_VERSION=1.18.152
+ENV AWS_CLI_S3_CMD=2.0.2
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.5
+ENV GOOGLE_CLOUD_SDK_VERSION=412.0.0
+ENV ECR_TOKEN_VERSION=v1.0.2
+ENV TARGETARCH=amd64
+
+
+ENV PATH "$PATH:/usr/local/bin/:/opt/google-cloud-sdk/bin/:/usr/local/bin/aws-iam-authenticator"
+
+
+#RUN apk update \
+#  && apk upgrade \
+#  && apk --no-cache add --update \
+#    bash \
+#    ca-certificates \
+#    wget \
+#    openjdk11 \
+#    git \
+#    openssh-client
+ 
+# AWS CLI
+RUN  microdnf install --setopt=tsflags=nodocs ca-certificates wget git openssh-clients python3-pip tar \
+  && pip3 install --upgrade awscli==${AWS_CLI_VERSION} s3cmd==${AWS_CLI_S3_CMD} python-magic \
+  && python3 -m pip uninstall pip -y
+
+# Google cloud SDK
+RUN [ $TARGETARCH == 'amd64' ] &&  export GCP_ARCH="x86_64" || export GCP_ARCH="arm"  \
+  && wget -nv https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
+  && mkdir -p /opt && cd /opt \
+  && tar -xzf /google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
+  && rm /google-cloud-sdk-${GOOGLE_CLOUD_SDK_VERSION}-linux-${GCP_ARCH}.tar.gz \
+  && CLOUDSDK_PYTHON="python3" /opt/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false \
+     --additional-components app-engine-java app-engine-go gke-gcloud-auth-plugin \
+  && rm -rf ~/.config/gcloud \
+  && rm -rf /opt/google-cloud-sdk/.install/.backup
+
+# kubectl + AWS IAM authenticator
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/${TARGETARCH}/kubectl \
+  && chmod +x kubectl \
+  && mv ./kubectl /usr/local/bin/kubectl \
+  && wget -O aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AWS_AIM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AWS_AIM_AUTHENTICATOR_VERSION}_linux_${TARGETARCH} \
+	&& chmod +x ./aws-iam-authenticator \
+	&& mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator\
+    && ln -sf /usr/local/bin/aws-iam-authenticator /usr/local/bin/heptio-authenticator-aws
+
+#RUN rm /var/cache/apk/*
+
+RUN groupadd -g 10111 spinnaker \
+  && useradd -g spinnaker -u 10111 spinnaker \
+  && mkdir -p /opt/clouddriver/plugins && chown -R spinnaker:spinnaker /opt/clouddriver/plugins
+
+COPY clouddriver-web/build/install/clouddriver /opt/clouddriver
+
+USER spinnaker
+
+CMD ["/opt/clouddriver/bin/clouddriver"]


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-19353
Changes done :

Copied Dockerfile.slim to Dockerfileubi8
Changed the base image from alpine to redhat
--- javabase file is committed at :
https://github.com/OpsMx/image-base-java/blob/main/Dockerfile
--- image is built and uploaded at:
http://quay.io/opsmxpublic/ubi8-jdk-11:v1

Added command to microdnf install required packages
Added group with group-id and added user with user-id
Changed ownership to plugins to the above spinnaker:spinnaker
Combined all RUN commands in single RUN command to avoid multiple layers