### PR TITLE
changes to force version in io.kubernetes:client-java-api as Ingress API is removed in higher versions 

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -83,6 +83,11 @@ dependencies {
   implementation "io.spinnaker.kork:kork-secrets"
   implementation "io.spinnaker.kork:kork-security"
   implementation "io.kubernetes:client-java"
+  implementation ("io.kubernetes:client-java-api:11.0.4"){
+    force = true
+  }
+
+
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
@@ -101,8 +106,8 @@ dependencies {
   testImplementation "org.junit.platform:junit-platform-runner"
   testImplementation "org.mockito:mockito-core"
   testImplementation "org.mockito:mockito-junit-jupiter"
-  testImplementation "cglib:cglib-nodep"
-  testImplementation "org.objenesis:objenesis"
+  testImplementation "cglib:cglib-nodep:3.3.0"
+  testImplementation "org.objenesis:objenesis:2.5.1"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"

--- a/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
+++ b/clouddriver-tencentcloud/clouddriver-tencentcloud.gradle
@@ -26,11 +26,11 @@ dependencies {
   implementation "com.google.guava:guava"
   implementation "com.tencentcloudapi:tencentcloud-sdk-java:3.1.51"
 
-  testImplementation "cglib:cglib-nodep"
+  testImplementation "cglib:cglib-nodep:3.3.0"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter"
   testImplementation "org.mockito:mockito-core"
-  testImplementation "org.objenesis:objenesis"
+  testImplementation "org.objenesis:objenesis:2.5.1"
   testImplementation "org.spockframework:spock-core"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"


### PR DESCRIPTION
hardcode the version to the older version io.kubernetes:client-java-api:11.0.4 as in v17.0.0 the Ingress API is now available via networking.k8s.io/v1beta1 and extensions/v1beta1 ingress objects are deprecated and removed
