### PR TITLE
Changed toBlocking() to blockingGet() as per rxjava3

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ElasticIpController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ElasticIpController.groovy
@@ -44,7 +44,7 @@ class ElasticIpController {
     } reduce(new HashSet<ElasticIp>(), { Set elasticIps, ElasticIp elasticIp ->
       elasticIps << elasticIp
       elasticIps
-    }) toBlocking() first()
+    }) blockingGet()
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{account}", params = ['region'])
@@ -54,6 +54,6 @@ class ElasticIpController {
     } reduce(new HashSet<ElasticIp>(), { Set elasticIps, ElasticIp elasticIp ->
       elasticIps << elasticIp
       elasticIps
-    }) toBlocking() first()
+    }) blockingGet()
   }
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/NetworkController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/NetworkController.groovy
@@ -44,7 +44,7 @@ class NetworkController {
       }
       networks[network.cloudProvider] << network
       networks
-    }) toBlocking() first()
+    }) blockingGet()
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/{cloudProvider}")

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SecurityGroupController.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SecurityGroupController.groovy
@@ -65,7 +65,7 @@ class SecurityGroupController {
       objs
     }) doOnError {
       log.error("Unable to list security groups", it)
-    } toBlocking() first()
+    } blockingGet()
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
@@ -84,7 +84,7 @@ class SecurityGroupController {
       }
       objs[obj.cloudProvider][obj.region] << obj.summary
       objs
-    }) toBlocking() first()
+    }) blockingGet()
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
@@ -101,7 +101,7 @@ class SecurityGroupController {
       }
       objs[obj.cloudProvider] << obj.summary
       objs
-    }) toBlocking() first()
+    }) blockingGet()
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
@@ -118,7 +118,7 @@ class SecurityGroupController {
       }
       objs[obj.region] << obj.summary
       objs
-    }) toBlocking() first()
+    }) blockingGet()
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
@@ -133,7 +133,7 @@ class SecurityGroupController {
     } reduce(sortedTreeSet, { Set objs, SecurityGroup obj ->
       objs << obj.summary
       objs
-    }) toBlocking() first()
+    }) blockingGet()
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
@@ -151,7 +151,7 @@ class SecurityGroupController {
       }
       objs[obj.region] << obj.summary
       objs
-    }) toBlocking() first()
+    }) blockingGet()
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")


### PR DESCRIPTION
## Summary
Project Jira : https://devopsmx.atlassian.net/browse/OP-20400 (Issue6)
Project Doc : NA

Issue : As we have migrated from rxjava1 to rxjava3 bcoz of sprngboot migration, earlier code was removed from rxjava3
Solution: changed earlier code with respective code as per rxjava3

### How changes are verified
Deployed my img on pod, hit /securityGroup API, no error logs in jaegar or on Network in ChromeDeveloperTool

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
Pre deployment steps : NA
Post deployment steps : NA
 
 