### PR TITLE
Fixed ClusteredSortAgentScheduler Test

### DIFF
--- a/cats/cats-redis/src/test/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentSchedulerTest.java
+++ b/cats/cats-redis/src/test/java/com/netflix/spinnaker/cats/redis/cluster/ClusteredSortAgentSchedulerTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Before;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 

--- a/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineConfigAtomicOperationConverterTest.java
+++ b/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/converters/DeployAppengineConfigAtomicOperationConverterTest.java
@@ -17,7 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.appengine.deploy.converters;
 
-import static org.springframework.test.util.AssertionErrors.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,7 +29,7 @@ import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class DeployAppengineConfigAtomicOperationConverterTest {
 

--- a/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineConfigAtomicOperationTest.java
+++ b/clouddriver-appengine/src/test/java/com/netflix/spinnaker/clouddriver/appengine/deploy/ops/DeployAppengineConfigAtomicOperationTest.java
@@ -17,7 +17,7 @@
 
 package com.netflix.spinnaker.clouddriver.appengine.deploy.ops;
 
-import static org.springframework.test.util.AssertionErrors.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class DeployAppengineConfigAtomicOperationTest {


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20335?focusedCommentId=63205&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-63205)
**Project Doc :** NA

**Issue :** java.lang.NullPointerException: Cannot invoke "com.netflix.spinnaker.cats.redis.cluster.ClusteredSortAgentScheduler.saturatePool()" because "this.clusteredSortAgentScheduler" is null
**Solution :** It is null bcoz it is not entering inside @Before block and bean remains null. It is not entering inside bcoz of wrong import

### How changes are verified
Test passed in intellij

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
Pre deployment steps : NA
Post deployment steps : NA