### PR TITLE
Removing unused dependency

### DIFF
--- a/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/DestroyOracleServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-oracle/src/test/groovy/com/netflix/spinnaker/clouddriver/oracle/deploy/op/DestroyOracleServerGroupAtomicOperationSpec.groovy
@@ -21,7 +21,6 @@ import com.oracle.bmc.loadbalancer.model.*
 import com.oracle.bmc.loadbalancer.requests.UpdateBackendSetRequest
 import com.oracle.bmc.loadbalancer.responses.GetLoadBalancerResponse
 import com.oracle.bmc.loadbalancer.responses.UpdateBackendSetResponse
-import groovy.ui.SystemOutputInterceptor
 import spock.lang.Specification
 
 class DestroyOracleServerGroupAtomicOperationSpec extends Specification {
@@ -49,8 +48,8 @@ class DestroyOracleServerGroupAtomicOperationSpec extends Specification {
     1 * loadBalancerClient.getLoadBalancer(_) >> GetLoadBalancerResponse.builder().loadBalancer(
       LoadBalancer.builder().backendSets(['myBackendSet': BackendSet.builder().backends(
         backends.collect { Backend.builder().ipAddress(it).build() } ).build()]).build()).build()
-    1 * sgService.getServerGroup(_, _, "sg1") >> 
-      new OracleServerGroup(loadBalancerId: "ocid.lb.oc1..12345", backendSetName: 'myBackendSet', 
+    1 * sgService.getServerGroup(_, _, "sg1") >>
+      new OracleServerGroup(loadBalancerId: "ocid.lb.oc1..12345", backendSetName: 'myBackendSet',
         instances: srvGroup.collect {new OracleInstance(id: it, privateIp: it)} as Set)
     1 * sgService.destroyServerGroup(_, _, "sg1")
     1 * loadBalancerClient.updateBackendSet(_) >> { args ->


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20335)
**Project Doc :** NA

**Issue :** SystemOutputInterceptor is unknown parameter in DestroyOracleServerGroupAtomicOperationSpec.groovy and giving error while running TC
**Solution :** Removed this import statement, confirmed from OSS, it is the unused one.

### How changes are verified
Error gone, TC running.

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
Pre deployment steps : NA
Post deployment steps : NA