### PR TITLE
fix for clouddriver loadbalances not loading issue

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonApplicationLoadBalancerCachingAgent.groovy
@@ -82,9 +82,9 @@ class AmazonApplicationLoadBalancerCachingAgent extends AbstractAmazonLoadBalanc
 
   @Override
   Optional<Map<String, String>> getCacheKeyPatterns() {
-    return [
+    return Optional.ofNullable([
       (LOAD_BALANCERS.ns): Keys.getLoadBalancerKey('*', account.name, region, 'vpc-????????', '*')
-    ]
+    ])
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/AmazonLoadBalancerCachingAgent.groovy
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.clouddriver.aws.edda.EddaApi
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.clouddriver.cache.OnDemandAgent
+import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace
 import com.netflix.spinnaker.clouddriver.model.LoadBalancer
 
 import static com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.*
@@ -55,9 +56,9 @@ class AmazonLoadBalancerCachingAgent extends AbstractAmazonLoadBalancerCachingAg
 
   @Override
   Optional<Map<String, String>> getCacheKeyPatterns() {
-    return [
+    return Optional.ofNullable([
       (LOAD_BALANCERS.ns): Keys.getLoadBalancerKey('*', account.name, region, 'vpc-????????', null)
-    ]
+    ])
   }
 
   @Override

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy
@@ -141,9 +141,9 @@ class ClusterCachingAgent implements CachingAgent, OnDemandAgent, AccountAware, 
 
   @Override
   Optional<Map<String, String>> getCacheKeyPatterns() {
-    return [
+    return Optional.ofNullable([
       (SERVER_GROUPS.ns): Keys.getServerGroupKey('*', '*', account.name, region)
-    ]
+    ])
   }
 
   static class AmazonClients {


### PR DESCRIPTION
RCA: 
  AmazonLoadBalancerCachingAgent , AmazonApplicationLoadBalancerCachingAgent and ClusterCachingAgents were failing due groovy conversion and hence caching was not happened, Error was looks like
  
  `org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object '{loadBalancers=aws:loadBalancers:spin-aws-test:us-east-1:*:vpc-????????:*}' with class 'java.util.LinkedHashMap' to class 'java.util.Optional' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: java.util.Optional(LinkedHashMap)
        at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnSAM(DefaultTypeTransformation.java:422) ~[groovy-4.0.11.jar:4.0.11]
        at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.continueCastOnNumber(DefaultTypeTransformation.java:335) ~[groovy-4.0.11.jar:4.0.11]
        at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:255) ~[groovy-4.0.11.jar:4.0.11]
        at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321) ~[groovy-4.0.11.jar:4.0.11]
        at com.netflix.spinnaker.clouddriver.aws.provider.agent.AmazonApplicationLoadBalancerCachingAgent.getCacheKeyPatterns(AmazonApplicationLoadBalancerCachingAgent.groovy:86)`
        
  