### PR TITLE
Added Junit5 changes in clouddriver-kubernetes

### DIFF
--- a/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/ArtifactKeyTest.java
+++ b/clouddriver-kubernetes/src/test/groovy/com/netflix/spinnaker/clouddriver/kubernetes/op/manifest/ArtifactKeyTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.artifacts.model.Artifact.ArtifactBuilder;
 import java.util.Collection;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactKeyTest {
   private static String TYPE = "docker/image";
   private static String NAME = "gcr.io/test/test-image";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactConverterTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactConverterTest {
   private static final String ACCOUNT = "my-account";
   private static final String NAMESPACE = "my-namespace";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ArtifactReplacerTest.java
@@ -52,10 +52,7 @@ import lombok.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactReplacerTest {
   // We serialized generated Kubernetes metadata objects with JSON io.kubernetes.client.openapi.JSON
   // so that they match what we get back from kubectl.  We'll just gson from converting to a

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ReplacerTest.java
@@ -35,8 +35,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * The goal of this class is to do a test on each of the statically-defined replacers in {@link
@@ -49,7 +47,6 @@ import org.junit.runner.RunWith;
  * (ex: do we properly filter artifacts by namespace/account) this class focuses on ensuring that
  * each static replacer works as expected.
  */
-@RunWith(JUnitPlatform.class)
 final class ReplacerTest {
   // We serialized generated Kubernetes metadata objects with JSON io.kubernetes.client.openapi.JSON
   // so that they match what we get back from kubectl.  We'll just gson from converting to a

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ResourceVersionerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/ResourceVersionerTest.java
@@ -38,12 +38,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 final class ResourceVersionerTest {
   private static final ObjectMapper mapper = new ObjectMapper();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/KeysTest.java
@@ -23,10 +23,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.caching.Keys.CacheKey;
 import java.util.Optional;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KeysTest {
   @ParameterizedTest
   @ValueSource(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCacheDataConverterTest.java
@@ -25,10 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesCacheDataConverterTest {
 
   @Test

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCachingAgentDispatcherTest.java
@@ -33,10 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesCachingAgentDispatcherTest {
 
   @Test

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesCoreCachingAgentTest.java
@@ -66,11 +66,8 @@ import lombok.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesCoreCachingAgentTest {
   private static final String ACCOUNT = "my-account";
   private static final String NAMESPACE1 = "test-namespace";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/agent/KubernetesUnregisteredCustomResourceCachingAgentTest.java
@@ -33,11 +33,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.lang.Nullable;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesUnregisteredCustomResourceCachingAgentTest {
 
   private static final String ACCOUNT = "my-account";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesDataProviderIntegrationTest.java
@@ -89,12 +89,9 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.internal.stubbing.defaultanswers.ReturnsSmartNulls;
 
 @ExtendWith(SoftAssertionsExtension.class)
-@RunWith(JUnitPlatform.class)
 final class KubernetesDataProviderIntegrationTest {
   private static final String ACCOUNT_NAME = "my-account";
   private static final Registry registry = new NoopRegistry();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesInstanceProviderTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesInstanceProviderTest.java
@@ -44,10 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesInstanceProviderTest {
 
   private KubernetesInstanceProvider provider;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesRawResourceProviderTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/caching/view/provider/KubernetesRawResourceProviderTest.java
@@ -38,10 +38,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesRawResourceProviderTest {
 
   private KubernetesRawResourceProvider provider;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinatesTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesCoordinatesTest.java
@@ -24,10 +24,7 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesCoordinatesTest {
   @ParameterizedTest
   @MethodSource("parseNameCases")

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesPodMetricTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/KubernetesPodMetricTest.java
@@ -28,10 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesPodMetricTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescriptionTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesEnableDisableManifestDescriptionTest.java
@@ -22,10 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesEnableDisableManifestDescriptionTest {
   private static final JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
   private static final ObjectMapper objectMapper = new ObjectMapper();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestOwnerRefTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestOwnerRefTest.java
@@ -22,10 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesManifestOwnerRefTest {
 
   @ParameterizedTest

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestReplicasTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestReplicasTest.java
@@ -23,10 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesManifestReplicasTest {
   private static final JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
   private static final ObjectMapper objectMapper = new ObjectMapper();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategyTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestStrategyTest.java
@@ -29,10 +29,7 @@ import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesManifestStrategyTest {
   @Test
   void deployStrategyDefaultsToApply() {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTest.java
@@ -22,10 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesManifestTest {
 
   private static final String GENERATE_NAME = "my-generate-name";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTrafficTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesManifestTrafficTest.java
@@ -22,10 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesManifestTrafficTest {
   @Test
   final void createNullTraffic() {

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
@@ -39,14 +39,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
-@RunWith(JUnitPlatform.class)
 @ExtendWith(MockitoExtension.class)
 final class KubernetesHealthIndicatorTest {
   private static final String ERROR_MESSAGE = "Failed to get namespaces";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/manifest/KubernetesDeployManifestConverterTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/manifest/KubernetesDeployManifestConverterTest.java
@@ -35,11 +35,8 @@ import java.nio.charset.Charset;
 import java.util.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesDeployManifestConverterTest {
   private static KubernetesDeployManifestConverter converter;
   private static ObjectMapper mapper;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesNamerRegistryTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/names/KubernetesNamerRegistryTest.java
@@ -25,10 +25,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import com.netflix.spinnaker.clouddriver.names.NamingStrategy;
 import com.netflix.spinnaker.moniker.Moniker;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesNamerRegistryTest {
   private static final NamingStrategy<KubernetesManifest> DEFAULT_NAMER =
       new KubernetesManifestNamer();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeleteManifestOperationTest.java
@@ -56,13 +56,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 /** Test the deleteManifest stage. */
-@RunWith(JUnitPlatform.class)
 public class KubernetesDeleteManifestOperationTest {
   private static final GlobalResourcePropertyRegistry resourcePropertyRegistry =
       new GlobalResourcePropertyRegistry(

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/KubernetesDeployManifestOperationTest.java
@@ -58,10 +58,7 @@ import com.netflix.spinnaker.moniker.Namer;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesDeployManifestOperationTest {
   private static final String DEFAULT_NAMESPACE = "default-namespace";
   private static final ResourcePropertyRegistry resourcePropertyRegistry =

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeployTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/CanDeployTest.java
@@ -35,10 +35,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentia
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesSelectorList;
 import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class CanDeployTest {
   private final CanDeploy handler = new CanDeploy() {};
   private final String OP_NAME = "Can Deploy Test";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesDaemonSetHandlerTest.java
@@ -22,10 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesDaemonSetHandlerTest {
   private KubernetesDaemonSetHandler handler = new KubernetesDaemonSetHandler();
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHorizontalPodAutoscalerHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHorizontalPodAutoscalerHandlerTest.java
@@ -22,10 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesHorizontalPodAutoscalerHandlerTest {
   private KubernetesHorizontalPodAutoscalerHandler handler =
       new KubernetesHorizontalPodAutoscalerHandler();

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesStatefulSetHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesStatefulSetHandlerTest.java
@@ -22,10 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest;
 import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest.Status;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesStatefulSetHandlerTest {
   private KubernetesStatefulSetHandler handler = new KubernetesStatefulSetHandler();
 

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubectlJobExecutorTest.java
@@ -73,11 +73,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.slf4j.LoggerFactory;
 
-@RunWith(JUnitPlatform.class)
 final class KubectlJobExecutorTest {
   private static final String NAMESPACE = "test-namespace";
   JobExecutor jobExecutor;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/op/job/KubernetesRunJobOperationTest.java
@@ -52,10 +52,7 @@ import com.netflix.spinnaker.moniker.Namer;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesRunJobOperationTest {
   private static final String NAMESPACE = "my-namespace";
   private static final String GENERATE_SUFFIX = "-abcd";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsLifecycleHandlerTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsLifecycleHandlerTest.java
@@ -36,11 +36,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 
-@RunWith(JUnitPlatform.class)
 public class KubernetesCredentialsLifecycleHandlerTest {
   KubernetesProvider provider;
   KubernetesCachingAgentDispatcher cachingAgentDispatcher;

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesCredentialsTest.java
@@ -47,10 +47,7 @@ import com.netflix.spinnaker.kork.configserver.CloudConfigResourceService;
 import com.netflix.spinnaker.kork.configserver.ConfigFileService;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesCredentialsTest {
   private static final String ACCOUNT_NAME = "my-account";
   private static final String DEPLOYMENT_NAME = "my-deployment";

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistryTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/security/KubernetesKindRegistryTest.java
@@ -26,10 +26,7 @@ import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.Kuberne
 import java.util.Collection;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesKindRegistryTest {
   private static final KubernetesApiGroup CUSTOM_API_GROUP = KubernetesApiGroup.fromString("test");
   private static final KubernetesKind CUSTOM_KIND =

--- a/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/MainSpec.java
+++ b/clouddriver-web/src/test/groovy/com/netflix/spinnaker/clouddriver/MainSpec.java
@@ -17,10 +17,12 @@
 package com.netflix.spinnaker.clouddriver;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-// @RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Main.class})
 @TestPropertySource(
     properties = {


### PR DESCRIPTION
## Summary
Added code changes to support JUnit5

**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20720)
**Project Doc :** NA

### How changes are verified
clouddriver compilation - success
before code changes - error while executing TCs
after code changes - 711/711 TCs passed [Ref](https://docs.google.com/spreadsheets/d/1bWOLaL3F_Fbe6P6CUyZJOqzMhWxw1j-Sl-9zE0pBtWw/edit?pli=1#gid=1454652396)

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA