### PR TITLE
Updating AWS_IAM_AUTHENTICATOR & GOOGLE_CLOUD_SDK - CVE fix

### DIFF
--- a/docker/ubi8/Dockerfile
+++ b/docker/ubi8/Dockerfile
@@ -6,21 +6,21 @@ LABEL summary='Red Hat certified Open Enterprise Spinnaker ubi8 container image 
 LABEL description='Certified Open Enterprise Spinnaker is an Enterprise grade, Red Hat certified and OpsMx supported release of the popular and critically acclaimed Continuous Delivery platform Spinnaker'
 LABEL vendor='OpsMx'
 
-RUN yum install -y python38 
+RUN yum install -y python38
 ARG TARGETARCH
 
 
 ENV KUBECTL_RELEASE=1.22.0
 ENV AWS_CLI_VERSION=1.18.152
 ENV AWS_CLI_S3_CMD=2.0.2
-ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.9
-ENV GOOGLE_CLOUD_SDK_VERSION=435.0.0
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
+ENV GOOGLE_CLOUD_SDK_VERSION=458.0.1
 ENV ECR_TOKEN_VERSION=v1.0.2
 
 ENV PATH "$PATH:/usr/local/bin/:/opt/google-cloud-sdk/bin/:/usr/local/bin/aws-iam-authenticator"
 
 USER root
-RUN yum -y install bash jq  tar unzip wget unzip procps  java-17-openjdk-devel.x86_64 vim  net-tools curl git 
+RUN yum -y install bash jq  tar unzip wget unzip procps  java-17-openjdk-devel.x86_64 vim  net-tools curl git
 
 # AWS CLI
 RUN yum -y install python3-pip && \

--- a/docker/ubi8/Dockerfile-dev
+++ b/docker/ubi8/Dockerfile-dev
@@ -36,14 +36,14 @@ RUN fips-mode-setup --enable
 # Setting crypto policies to FIPS
 RUN update-crypto-policies --set FIPS
 
-RUN yum install -y python38 
+RUN yum install -y python38
 ARG TARGETARCH
 
 
 ENV KUBECTL_RELEASE=1.22.0
 ENV AWS_CLI_S3_CMD=2.0.2
-ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.9
-ENV GOOGLE_CLOUD_SDK_VERSION=435.0.0
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
+ENV GOOGLE_CLOUD_SDK_VERSION=458.0.1
 ENV ECR_TOKEN_VERSION=v1.0.2
 
 ENV PATH "$PATH:/usr/local/bin/:/opt/google-cloud-sdk/bin/:/usr/local/bin/aws-iam-authenticator"
@@ -51,7 +51,7 @@ ENV PATH "$PATH:/usr/local/bin/:/opt/google-cloud-sdk/bin/:/usr/local/bin/aws-ia
 USER root
 
 
-#RUN yum -y install bash jq  tar unzip wget procps  java-17-openjdk-devel.x86_64 vim  net-tools curl git 
+#RUN yum -y install bash jq  tar unzip wget procps  java-17-openjdk-devel.x86_64 vim  net-tools curl git
 
 RUN yum -y install  wget git
 
@@ -85,8 +85,8 @@ RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RE
 RUN mkdir -p /opt/jaeger
 COPY jaeger/opentelemetry-javaagent.jar /opt/jaeger/opentelemetry-javaagent.jar
 
-#RUN yum -y remove  tar  curl 
-#RUN yum -y remove  vim  jq unzip 
+#RUN yum -y remove  tar  curl
+#RUN yum -y remove  vim  jq unzip
 RUN yum -y remove clean all && rm -rf /var/cache
 
 
@@ -107,7 +107,7 @@ ENV CUSTOMPLUGIN_RELEASEREPO=$CUSTOMPLUGIN_RELEASEREPO
 ARG CUSTOMPLUGIN_RELEASEVERSION
 ENV CUSTOMPLUGIN_RELEASEVERSION=$CUSTOMPLUGIN_RELEASEVERSION
 
-RUN wget -O Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip -c https://github.com/${CUSTOMPLUGIN_RELEASEORG}/${CUSTOMPLUGIN_RELEASEREPO}/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}.zip -P /opt/clouddriver/plugins 
+RUN wget -O Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip -c https://github.com/${CUSTOMPLUGIN_RELEASEORG}/${CUSTOMPLUGIN_RELEASEREPO}/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}.zip -P /opt/clouddriver/plugins
 
 RUN mv Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip /opt/clouddriver/plugins/
 

--- a/docker/ubi8/Dockerfile-fips
+++ b/docker/ubi8/Dockerfile-fips
@@ -42,14 +42,14 @@ ARG TARGETARCH
 
 ENV KUBECTL_RELEASE=1.22.0
 ENV AWS_CLI_S3_CMD=2.0.2
-ENV AWS_AIM_AUTHENTICATOR_VERSION=0.5.9
-ENV GOOGLE_CLOUD_SDK_VERSION=435.0.0
+ENV AWS_AIM_AUTHENTICATOR_VERSION=0.6.14
+ENV GOOGLE_CLOUD_SDK_VERSION=458.0.1
 ENV ECR_TOKEN_VERSION=v1.0.2
 
 ENV PATH "$PATH:/usr/local/bin/:/opt/google-cloud-sdk/bin/:/usr/local/bin/aws-iam-authenticator"
 
 USER root
-#RUN yum -y install bash jq  tar unzip wget procps  java-17-openjdk-devel.x86_64 vim  net-tools curl git 
+#RUN yum -y install bash jq  tar unzip wget procps  java-17-openjdk-devel.x86_64 vim  net-tools curl git
 
 RUN yum -y install  wget git
 
@@ -82,8 +82,8 @@ COPY clouddriver-web/build/install/clouddriver /opt/clouddriver
 
 
 
-#RUN yum -y remove  tar  curl 
-#RUN yum -y remove  vim  jq unzip 
+#RUN yum -y remove  tar  curl
+#RUN yum -y remove  vim  jq unzip
 RUN yum -y remove clean all && rm -rf /var/cache
 
 RUN adduser spinnaker
@@ -102,7 +102,7 @@ ENV CUSTOMPLUGIN_RELEASEVERSION=$CUSTOMPLUGIN_RELEASEVERSION
 
 
 
-RUN wget -O Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip -c https://github.com/${CUSTOMPLUGIN_RELEASEORG}/${CUSTOMPLUGIN_RELEASEREPO}/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}.zip -P /opt/clouddriver/plugins 
+RUN wget -O Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip -c https://github.com/${CUSTOMPLUGIN_RELEASEORG}/${CUSTOMPLUGIN_RELEASEREPO}/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}.zip -P /opt/clouddriver/plugins
 RUN mv Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip /opt/clouddriver/plugins/
 
 RUN chmod -R 777 /opt/clouddriver/plugins/


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21540) and other related Jiras
**Project Doc :** NA

**Issue/Feature :** Vulnerabilities in go pckgs
**Solution :** Updating  AWS_IAM_AUTHENTICATOR & GOOGLE_CLOUD_SDK versions to latest

### How changes are verified
1. Build success, No new TCs failing
2. Created new dockerImg, deployed on ns=testframe, verified changes by running 3-4 pipelines, watched the logs and didnt find any errors.
DockerImg for ref : aman1603/clouddriver:3jan2
3. Scanned the dockerImg using trivy on local ubuntu system & found that mentioned CVEs are resolved/fixed.

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** @yugaa22 pls update github actions accordingly
**Post deployment steps :** QA need to test more rigorously.