### PR TITLE
Removed explicit json-path dependency version from clouddriver-kubern…

### DIFF
--- a/clouddriver-kubernetes/clouddriver-kubernetes.gradle
+++ b/clouddriver-kubernetes/clouddriver-kubernetes.gradle
@@ -66,7 +66,7 @@ dependencies {
   implementation "org.apache.groovy:groovy-all:4.0.11"
   implementation "com.google.code.findbugs:jsr305"
   implementation "com.google.guava:guava"
-  implementation 'com.jayway.jsonpath:json-path:2.3.0'
+  implementation 'com.jayway.jsonpath:json-path'
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "com.github.wnameless.json:json-flattener:0.11.1"
   implementation "com.netflix.frigga:frigga:0.26.0"


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21632)
**Project Doc :** NA

**Issue :** Dependency coming from kork-bom
**Solution :** No need to put explicit version in clouddriver-kubernetes.gradle

### How changes are verified
clouddriver build successful, clouddriver-kubernetes TCs passing 711/711

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** QA need to do regression testing