### PR TITLE
Fixed the Docker accounts not loading issue by removing docker related configuration in clouddriver.yml. Once we remove here, it will pick the docker accounts from hal config. OP-21764

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -257,9 +257,6 @@ kubernetes:
   v2:
     applyAppLabels: true
 
-dockerRegistry:
-  enabled: ${DOCKER_REGISTRY_ENABLED:false}
-
 dcos:
   enabled: false
 


### PR DESCRIPTION
Fixed the Docker accounts not loading issue by removing docker related configuration in clouddriver.yml. Once we remove here, it will pick the docker accounts from hal config. OP-21764

