### PR TITLE
OP-21844 Fixed postgresql cve by upgrading it to 4.7.2. CVE-2024-1597

### DIFF
--- a/clouddriver-sql-postgres/clouddriver-sql-postgres.gradle
+++ b/clouddriver-sql-postgres/clouddriver-sql-postgres.gradle
@@ -2,5 +2,5 @@ dependencies {
   implementation project(":cats:cats-sql")
   implementation project(":clouddriver-sql")
 
-  runtimeOnly "org.postgresql:postgresql:42.2.18"
+  runtimeOnly "org.postgresql:postgresql"
 }


### PR DESCRIPTION
Jira : https://devopsmx.atlassian.net/browse/OP-21844
Summary : Upgraded postgresql version
Testing :

compile successful, no new TCs failed bcoz of this.
service started successfully after this change.
Created trivy-scan locally, this CVE not found
Pre-merge : NA
Post-merge : QA regression testing