### PR TITLE
OP-21880 Fixed CVE-2023-31582 - Upgraded org.bitbucket.b_c & indented…

### DIFF
--- a/clouddriver-artifacts/clouddriver-artifacts.gradle
+++ b/clouddriver-artifacts/clouddriver-artifacts.gradle
@@ -58,6 +58,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.junit.platform:junit-platform-commons:1.9.0"
+  implementation "org.bitbucket.b_c:jose4j:0.9.6"
 
   testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
   testImplementation "io.spinnaker.kork:kork-aws"

--- a/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
+++ b/clouddriver-sql/src/test/java/com/netflix/spinnaker/clouddriver/sql/SqlTaskRepositoryTest.java
@@ -22,10 +22,8 @@ import com.netflix.spinnaker.config.ConnectionPools;
 import com.netflix.spinnaker.kork.sql.config.RetryProperties;
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties;
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil;
-import org.junit.jupiter.api.AfterEach;
-
 import java.time.Clock;
-
+import org.junit.jupiter.api.AfterEach;
 
 public class SqlTaskRepositoryTest extends TaskRepositoryTck {
 


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21880
**Summary** : Upgraded org.bitbucket.b_c & indented SqlTaskRepositoryTest
**Testing** :
compile successful, no new TCs failed bcoz of this.
service started successfully after this change.
Created trivy-scan locally : aman1603/clouddriver:8march1, this CVE not found
**Pre_merge** : NA
**Post_merge** : QA regression testing