### PR TITLE
OP-21877 Remove explicit google-guava version

### DIFF
--- a/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver-azure/clouddriver-azure.gradle
@@ -19,7 +19,7 @@ dependencies {
   implementation("io.projectreactor:reactor-core:3.4.23") {
     force = true
   }
-  implementation "com.google.guava:guava:31.1-jre"
+  implementation "com.google.guava:guava"
   implementation "org.apache.groovy:groovy"
 
   testImplementation "cglib:cglib-nodep:3.3.0"


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21877
**Summary** : Removed explicit version of com.google.guava version
**Testing** :
compile successful, no new TCs failed bcoz of this.
publish local maven, did DI on clouddriver, piucking latest version as mentioned in kork
service started successfully after this change.

**Pre_merge** : NA
**Post_merge** : QA regression testing