### PR TITLE
OP-21077 Upgraded jooq versio to 3.17.14

### DIFF
--- a/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgentTest.kt
+++ b/cats/cats-sql/src/test/kotlin/com/netflix/spinnaker/cats/sql/cache/SqlUnknownAgentCleanupAgentTest.kt
@@ -27,18 +27,12 @@ import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.INSTANCES
 import com.netflix.spinnaker.clouddriver.core.provider.agent.Namespace.SERVER_GROUPS
 import com.netflix.spinnaker.config.SqlConstraintsInitializer
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import de.huxhorn.sulky.ulid.ULID
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import org.jooq.DSLContext
 import org.jooq.SQLDialect
-import org.jooq.impl.DSL
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.table
-import org.jooq.impl.DefaultConfiguration
-import org.jooq.impl.DefaultDSLContext
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.beans.factory.ObjectProvider
@@ -60,7 +54,6 @@ class SqlUnknownAgentCleanupAgentTest : JUnit5Minutests {
 
     after {
       SqlTestUtil.cleanupDb(dslContext)
-      dslContext.close()
     }
 
     context("test and prod accounts exist") {

--- a/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgentTest.kt
+++ b/clouddriver-sql/src/test/kotlin/com/netflix/spinnaker/clouddriver/sql/SqlTaskCleanupAgentTest.kt
@@ -17,19 +17,14 @@
 
 package com.netflix.spinnaker.clouddriver.sql
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.clouddriver.sql.event.SqlEventCleanupAgent
-import com.netflix.spinnaker.config.SqlEventCleanupAgentConfigProperties
 import com.netflix.spinnaker.config.SqlTaskCleanupAgentProperties
-import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.every
-import io.mockk.mockk
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
-import java.sql.Timestamp
 import java.time.Clock
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -54,7 +49,7 @@ class SqlTaskCleanupAgentTest : JUnit5Minutests {
             "7b96fe8de1e5e8e8620036480771195b8e25c583c9f4f0098a23e97bf2ba013b",
             "95637b33-6699-4abf-b1ab-d4077e1cf867@spin-clouddriver-7847bc646b-hgkfd",
             ts.toEpochMilli(),
-            mutableListOf<String>()
+            jacksonObjectMapper().writeValueAsString(mutableListOf<String>())
           )
           .execute()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
-fiatVersion=1-0-SNAPSHOT
-korkVersion=1.33.3-nemesis-SNAPSHOT
+fiatVersion=1.33.0-SNAPSHOT
+korkVersion=1.33.0-SNAPSHOT
 org.gradle.parallel=true
 spinnakerGradleVersion=1-0-SNAPSHOT
-#targetJava11=true
 kotlinVersion=1.9.21
 
 # To enable a composite reference to a project, set the


### PR DESCRIPTION
**Details** : https://devopsmx.atlassian.net/browse/OP-21077

**Summary**: 
- updated snapshot versions in gradle.properties
- removed unused imports
- removed dslContext.close() : [ref](https://github.com/spinnaker/clouddriver/pull/6155/files)
- replaced mutableListOf<String>() by jacksonObjectMapper().writeValueAsString(mutableListOf<String>()) 
  - oss used jackson.databind.ObjectMapperObjectMapper [ref](https://github.com/spinnaker/clouddriver/pull/6155/files), i prefer kotlin.jacksonObjectMapper, bcoz it's a convenient method to quickly get an ObjectMapper instance with Kotlin support & it includes default configurations and modules specifically suited for Kotlin, such as handling Kotlin data classes, default parameters, and null safety.

**Testing** : build success & no UT fail due to this change in clouddriver