### PR TITLE
OP-22460 Removed the front50 config as it is picking up this address …

### DIFF
--- a/clouddriver-web/config/clouddriver.yml
+++ b/clouddriver-web/config/clouddriver.yml
@@ -12,7 +12,7 @@ redis:
 
 services:
   front50:
-    baseUrl: http://localhost:8080
+    baseUrl: http://spin-front50:8080
 
 management.health.elasticsearch.enabled: false
 


### PR DESCRIPTION
OP-22460 Removed the front50 config as it is picking up this address and the baked image deployment is failing.

